### PR TITLE
Add AutoridadDeLaAvaricia plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+}
+
+group = 'gg.tomas.avaria'
+version = '1.0.0'
+sourceCompatibility = JavaVersion.VERSION_21
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    from sourceSets.main.allSource
+    archiveClassifier.set('sources')
+}
+
+repositories {
+    mavenCentral()
+    maven { url 'https://repo.papermc.io/repository/maven-public/' }
+}
+
+dependencies {
+    compileOnly 'io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT'
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'gg.tomas.avaria.Main'
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'AutoridadDeLaAvaricia'

--- a/src/main/java/gg/tomas/avaria/Main.java
+++ b/src/main/java/gg/tomas/avaria/Main.java
@@ -1,0 +1,66 @@
+package gg.tomas.avaria;
+
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import gg.tomas.avaria.managers.AbilityManager;
+import gg.tomas.avaria.managers.InventoryManager;
+import gg.tomas.avaria.util.Items;
+import gg.tomas.avaria.listeners.PlayerListener;
+
+/**
+ * Main plugin class for AutoridadDeLaAvaricia.
+ */
+public class Main extends JavaPlugin {
+
+    private static Main instance;
+    private NamespacedKey authorityKey;
+    private FileConfiguration config;
+    private AbilityManager abilityManager;
+    private InventoryManager inventoryManager;
+
+    public static Main getInstance() {
+        return instance;
+    }
+
+    @Override
+    public void onEnable() {
+        instance = this;
+        saveDefaultConfig();
+        config = getConfig();
+        authorityKey = new NamespacedKey(this, "hasAuthority");
+        abilityManager = new AbilityManager(this);
+        inventoryManager = new InventoryManager(abilityManager);
+
+        Bukkit.getPluginManager().registerEvents(new PlayerListener(this, abilityManager, inventoryManager), this);
+    }
+
+    @Override
+    public void onDisable() {
+        abilityManager.cleanup();
+    }
+
+    public NamespacedKey getAuthorityKey() {
+        return authorityKey;
+    }
+
+    public double getDropChance() {
+        return config.getDouble("drop-chance", 0.01);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (command.getName().equalsIgnoreCase("avaricia") && sender instanceof Player player) {
+            ItemStack gene = Items.getWitchGene();
+            player.getInventory().addItem(gene);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/gg/tomas/avaria/listeners/PlayerListener.java
+++ b/src/main/java/gg/tomas/avaria/listeners/PlayerListener.java
@@ -1,0 +1,143 @@
+package gg.tomas.avaria.listeners;
+
+import java.util.Random;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerAnimationEvent;
+import org.bukkit.event.player.PlayerAnimationType;
+import org.bukkit.Particle;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+import gg.tomas.avaria.Main;
+import gg.tomas.avaria.managers.AbilityManager;
+import gg.tomas.avaria.managers.InventoryManager;
+import gg.tomas.avaria.util.Items;
+
+/**
+ * Handles player events for the authority.
+ */
+public class PlayerListener implements Listener {
+
+    private final Main plugin;
+    private final AbilityManager abilityManager;
+    private final InventoryManager invManager;
+    private final Random random = new Random();
+
+    public PlayerListener(Main plugin, AbilityManager abilityManager, InventoryManager invManager) {
+        this.plugin = plugin;
+        this.abilityManager = abilityManager;
+        this.invManager = invManager;
+    }
+
+    @EventHandler
+    public void onUseGene(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() != Material.NETHER_STAR) return;
+        if (!ChatColor.stripColor(item.getItemMeta().getDisplayName()).equals("Gen de la Bruja")) return;
+        Player player = event.getPlayer();
+        NamespacedKey key = plugin.getAuthorityKey();
+        if (player.getPersistentDataContainer().has(key, PersistentDataType.BYTE)) return;
+        player.getPersistentDataContainer().set(key, PersistentDataType.BYTE, (byte)1);
+        ItemStack heart = Items.getHeartOfGreed();
+        player.getInventory().addItem(heart);
+        item.setAmount(item.getAmount()-1);
+    }
+
+    @EventHandler
+    public void onHeartToggle(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() != Material.CLOCK) return;
+        if (!ChatColor.stripColor(item.getItemMeta().getDisplayName()).equals("Coraz\u00f3n de la Avaricia")) return;
+        event.setCancelled(true);
+        Player player = event.getPlayer();
+        if (invManager.isInAbilityMode(player)) {
+            invManager.exitAbilityMode(player);
+        } else {
+            invManager.enterAbilityMode(player);
+        }
+    }
+
+    @EventHandler
+    public void onSwing(PlayerAnimationEvent event) {
+        if (event.getAnimationType() != PlayerAnimationType.ARM_SWING) return;
+        Player player = event.getPlayer();
+        if (!invManager.isInAbilityMode(player)) return;
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item.getType() != Material.IRON_SWORD) return;
+        if (!ChatColor.stripColor(item.getItemMeta().getDisplayName()).equals("Corte de Viento")) return;
+        if (!abilityManager.canUseWindSlash(player)) return;
+        abilityManager.triggerWindSlash(player);
+        player.getWorld().playSound(player.getLocation(), "entity.ender_dragon.flap", 1f, 1f);
+        // simplified beam
+        for (int i = 0; i < (abilityManager.isLionHeartActive(player) ? 60 : 40); i++) {
+            player.getWorld().spawnParticle(org.bukkit.Particle.SWEEP_ATTACK, player.getEyeLocation().add(player.getLocation().getDirection().multiply(i)), 1);
+        }
+    }
+
+    @EventHandler
+    public void onDrop(PlayerDropItemEvent event) {
+        ItemStack item = event.getItemDrop().getItemStack();
+        if (item.getType() == Material.CLOCK) {
+            String name = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+            if ("Coraz\u00f3n de la Avaricia".equals(name)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onMoveItem(InventoryClickEvent event) {
+        ItemStack item = event.getCurrentItem();
+        if (item != null && item.getType() == Material.CLOCK) {
+            String name = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+            if ("Coraz\u00f3n de la Avaricia".equals(name)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        if (abilityManager.isLionHeartActive(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        NamespacedKey key = plugin.getAuthorityKey();
+        boolean hadAuthority = player.getPersistentDataContainer().has(key, PersistentDataType.BYTE);
+        if (hadAuthority) {
+            player.getPersistentDataContainer().remove(key);
+            if (random.nextDouble() < plugin.getDropChance()) {
+                event.getDrops().add(Items.getWitchGene());
+            }
+        }
+        if (invManager.isInAbilityMode(player)) {
+            invManager.exitAbilityMode(player);
+        }
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        abilityManager.removeLink(event.getPlayer());
+    }
+}

--- a/src/main/java/gg/tomas/avaria/managers/AbilityManager.java
+++ b/src/main/java/gg/tomas/avaria/managers/AbilityManager.java
@@ -1,0 +1,132 @@
+package gg.tomas.avaria.managers;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import gg.tomas.avaria.Main;
+
+/**
+ * Manages abilities and Lion's Heart state per player.
+ */
+public class AbilityManager {
+
+    private final JavaPlugin plugin;
+    private final Map<UUID, PlayerData> playerData = new HashMap<>();
+    private BukkitRunnable task;
+
+    public AbilityManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        startTask();
+    }
+
+    public void toggleLionHeart(Player player) {
+        PlayerData data = playerData.computeIfAbsent(player.getUniqueId(), k -> new PlayerData());
+        if (data.cooldown > 0) return;
+        data.active = !data.active;
+        if (data.active) {
+            data.timer = data.linked != null ? Integer.MAX_VALUE : 100;
+            player.addScoreboardTag("lionHeartActive");
+        } else {
+            player.removeScoreboardTag("lionHeartActive");
+            data.cooldown = 60; // 3s
+        }
+    }
+
+    public boolean isLionHeartActive(Player player) {
+        PlayerData data = playerData.get(player.getUniqueId());
+        return data != null && data.active;
+    }
+
+    public boolean canUseWindSlash(Player player) {
+        PlayerData data = playerData.computeIfAbsent(player.getUniqueId(), k -> new PlayerData());
+        return data.windCooldown <= 0;
+    }
+
+    public void triggerWindSlash(Player player) {
+        PlayerData data = playerData.computeIfAbsent(player.getUniqueId(), k -> new PlayerData());
+        data.windCooldown = isLionHeartActive(player) ? 100 : 140; // 5s vs 7s
+    }
+
+    public void setLink(Player player, LivingEntity target) {
+        PlayerData data = playerData.computeIfAbsent(player.getUniqueId(), k -> new PlayerData());
+        data.linked = target.getUniqueId();
+        data.timer = Integer.MAX_VALUE;
+    }
+
+    public void removeLink(Player player) {
+        PlayerData data = playerData.get(player.getUniqueId());
+        if (data != null) {
+            data.linked = null;
+        }
+    }
+
+    public void cleanup() {
+        if (task != null) task.cancel();
+        playerData.clear();
+    }
+
+    private void startTask() {
+        task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (UUID id : playerData.keySet()) {
+                    Player player = Bukkit.getPlayer(id);
+                    if (player == null) continue;
+                    PlayerData data = playerData.get(id);
+                    if (data.active) {
+                        data.timer--;
+                        if (data.timer <= 0) {
+                            double dmg = player.getAttribute(Attribute.MAX_HEALTH).getValue() / 2.0 + 0.5;
+                            player.damage(dmg);
+                            player.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 20, 1));
+                            data.timer = data.linked != null ? Integer.MAX_VALUE : 100;
+                            data.active = false;
+                            player.removeScoreboardTag("lionHeartActive");
+                        }
+                    } else if (data.cooldown > 0) {
+                        data.cooldown--;
+                    }
+                    if (data.windCooldown > 0) {
+                        data.windCooldown--;
+                    }
+                    if (data.linked != null) {
+                        LivingEntity linked = getLinkedEntity(data.linked);
+                        if (linked == null || linked.isDead()) {
+                            removeLink(player);
+                            data.timer = 100;
+                            player.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, 40, 0));
+                        }
+                    }
+                }
+            }
+        };
+        task.runTaskTimer(plugin, 1L, 1L);
+    }
+
+    private LivingEntity getLinkedEntity(UUID uuid) {
+        Entity e = Bukkit.getEntity(uuid);
+        return e instanceof LivingEntity ? (LivingEntity) e : null;
+    }
+
+    private static class PlayerData {
+        boolean active = false;
+        int timer = 100;
+        int cooldown = 0;
+        int windCooldown = 0;
+        UUID linked = null;
+    }
+}

--- a/src/main/java/gg/tomas/avaria/managers/InventoryManager.java
+++ b/src/main/java/gg/tomas/avaria/managers/InventoryManager.java
@@ -1,0 +1,46 @@
+package gg.tomas.avaria.managers;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+
+import gg.tomas.avaria.util.Items;
+
+/**
+ * Handles inventory swapping between normal and ability modes.
+ */
+public class InventoryManager {
+
+    private final Map<UUID, ItemStack[]> normalInvs = new HashMap<>();
+    private final AbilityManager abilityManager;
+
+    public InventoryManager(AbilityManager abilityManager) {
+        this.abilityManager = abilityManager;
+    }
+
+    public void enterAbilityMode(Player player) {
+        PlayerInventory inv = player.getInventory();
+        normalInvs.put(player.getUniqueId(), inv.getContents());
+        inv.clear();
+        inv.setItem(0, Items.getLionHeartItem());
+        inv.setItem(1, Items.getWindSlashItem());
+        inv.setItem(2, Items.getLionCoreItem());
+    }
+
+    public void exitAbilityMode(Player player) {
+        PlayerInventory inv = player.getInventory();
+        ItemStack[] saved = normalInvs.remove(player.getUniqueId());
+        if (saved != null) {
+            inv.clear();
+            inv.setContents(saved);
+        }
+    }
+
+    public boolean isInAbilityMode(Player player) {
+        return normalInvs.containsKey(player.getUniqueId());
+    }
+}

--- a/src/main/java/gg/tomas/avaria/util/Items.java
+++ b/src/main/java/gg/tomas/avaria/util/Items.java
@@ -1,0 +1,54 @@
+package gg.tomas.avaria.util;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Helper class to create plugin items.
+ */
+public class Items {
+
+    public static ItemStack getWitchGene() {
+        ItemStack gene = new ItemStack(Material.NETHER_STAR);
+        ItemMeta meta = gene.getItemMeta();
+        meta.setDisplayName(ChatColor.GOLD + "Gen de la Bruja");
+        gene.setItemMeta(meta);
+        return gene;
+    }
+
+    public static ItemStack getHeartOfGreed() {
+        ItemStack heart = new ItemStack(Material.CLOCK);
+        ItemMeta meta = heart.getItemMeta();
+        meta.setDisplayName(ChatColor.RED + "Coraz\u00f3n de la Avaricia");
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+        heart.setItemMeta(meta);
+        return heart;
+    }
+
+    public static ItemStack getLionHeartItem() {
+        ItemStack book = new ItemStack(Material.BOOK);
+        ItemMeta meta = book.getItemMeta();
+        meta.setDisplayName(ChatColor.GREEN + "Detener Cuerpo");
+        book.setItemMeta(meta);
+        return book;
+    }
+
+    public static ItemStack getWindSlashItem() {
+        ItemStack sword = new ItemStack(Material.IRON_SWORD);
+        ItemMeta meta = sword.getItemMeta();
+        meta.setDisplayName(ChatColor.AQUA + "Corte de Viento");
+        sword.setItemMeta(meta);
+        return sword;
+    }
+
+    public static ItemStack getLionCoreItem() {
+        ItemStack heart = new ItemStack(Material.HEART_OF_THE_SEA);
+        ItemMeta meta = heart.getItemMeta();
+        meta.setDisplayName(ChatColor.LIGHT_PURPLE + "Coraz\u00f3n de Le\u00f3n");
+        heart.setItemMeta(meta);
+        return heart;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,1 @@
+drop-chance: 0.01

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,11 @@
+name: AutoridadDeLaAvaricia
+main: gg.tomas.avaria.Main
+version: 1.0.0
+api-version: "1.21.3"
+commands:
+  avaricia:
+    description: Otorga un Gen de la Bruja
+    permission: avaricia.admin
+permissions:
+  avaricia.admin:
+    default: op


### PR DESCRIPTION
## Summary
- set up gradle project with Paper dependency
- implement `Main` plugin with `/avaricia` command
- add ability and inventory managers
- create event listener for core functions
- provide plugin configuration and item helpers

## Testing
- `gradle build --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684f8d5d2ba483299e3c0b979dfa86c2